### PR TITLE
Adding documentation packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ cython
 orbitize
 pytest
 pandas
+sphinx
+sphinxcontrib-napoleon
+sphinx-rtd-theme


### PR DESCRIPTION
Adding sphinx, sphinxcontrib-napoleon, and sphinx-rtd-theme packages to requirements.txt. Previously we installed them during the documentation lesson, but this way all participants will have them installed already. 