### PR TITLE
Add links to 2025 and 2022 lecture recordings

### DIFF
--- a/workshop_info.md
+++ b/workshop_info.md
@@ -3,6 +3,8 @@ This is a "cheatsheet" of information for the workshop. Please let us know if th
 - Code of Conduct: https://docs.google.com/presentation/d/1sp7KDj7hJYAO8HbqRTTLEEa2DIiFknIayVy1iD_h0G4/edit#slide=id.g86f14c9d87_0_78
 - Workshop website: https://semaphorep.github.io/codeastro/
 - Workshop GitHub (course materials): https://github.com/semaphoreP/codeastro
+- Lecture Recordings (2025): https://www.youtube.com/watch?v=qYsa25eMveA&list=PLTNjIIFfMXAU7UgiTQLEm67j57zxwPmxN
+- Lecture Recordings (2022): https://www.youtube.com/playlist?list=PLb1880Rn0qkK7zTWcqGaXNbKZbxkpvUuH
 - Calendar (has room & zoom info): https://calendar.google.com/calendar/u/0/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America/Los_Angeles&src=ZTExaWdnaGdncmU5a2FnaTg4bDM3Z2FkODhAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23009688&title=Code/Astro
 - Discord (for discussions; invite-only): https://discord.com/channels/851894981999591424/851899721479749652
 - Piazza (for questions; invite-only): [https://piazza.com/class/lxpaku2gmn92rx](https://piazza.com/class/mcfn4vfdp3l3ey)


### PR DESCRIPTION
Add links to 2025 and 2022 lecture recordings to the workshop cheat sheet.